### PR TITLE
Pass arguments to verify command

### DIFF
--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -94,7 +94,7 @@ function release(cwd, pkg, options) {
     return Bluebird.each(publishTasks, runTask);
   }
 
-  return runVerify()
+  return runVerify(cwd, pkg, options)
     .then(options.commit ? runPublishTasks : _.noop)
     .then(options.commit ? publishToNpm : _.noop);
 }


### PR DESCRIPTION
We're getting closer! Fixes:

```
TypeError: Cannot set property 'pr' of undefined
    at verify (/home/travis/build/groupon/nlm/lib/commands/verify.js:66:14)
    at release (/home/travis/build/groupon/nlm/lib/commands/release.js:97:10)
    at Object.<anonymous> (/home/travis/build/groupon/nlm/lib/cli.js:98:3)
```