### PR TITLE
fix: Call publishToNpm as a task/step

### DIFF
--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -68,6 +68,7 @@ function release(cwd, pkg, options) {
     createVersionCommit,
     pushReleaseToRemote,
     createGithubRelease,
+    publishToNpm,
   ];
 
   function runTask(task) {
@@ -95,7 +96,6 @@ function release(cwd, pkg, options) {
   }
 
   return runVerify(cwd, pkg, options)
-    .then(options.commit ? runPublishTasks : _.noop)
-    .then(options.commit ? publishToNpm : _.noop);
+    .then(options.commit ? runPublishTasks : _.noop);
 }
 module.exports = release;


### PR DESCRIPTION
`.then(publishToNpm)` wasn't passing the required `(cwd, pkg, options)` arguments. Running it as a task like all the others fixes that.