### PR TITLE
Link to issues and tickets in changelog

### DIFF
--- a/lib/git/commits.js
+++ b/lib/git/commits.js
@@ -49,7 +49,9 @@ function parseCommit(commit) {
   var sha = meta.shift();
   var parentSha = meta.shift() || null;
 
-  var data = commitParser.sync(message);
+  var data = commitParser.sync(message, {
+    issuePrefixes: ['#', 'https?://\\w[\\w.-]*[\\w/-]+?'],
+  });
   var prMatch = message.match(PR_MERGE_PATTERN);
   if (prMatch) {
     var prId = prMatch[1];

--- a/lib/steps/changelog.js
+++ b/lib/steps/changelog.js
@@ -111,8 +111,20 @@ function generateChangeLog(cwd, pkg, options) {
     ].join('\n');
   }
 
+  function formatReference(ref) {
+    return '[' + ref.prefix + ref.issue + '](' + ref.href + ')';
+  }
+
+  function formatReferences(refs) {
+    if (!refs || refs.length === 0) return '';
+    return ' - see: ' + refs.map(formatReference).join(', ');
+  }
+
   function formatCommit(commit) {
-    return getCommitLink(commit) + ' **' + commit.type + ':** ' + commit.subject;
+    return getCommitLink(commit) +
+      ' **' + commit.type + ':** ' +
+      commit.subject +
+      formatReferences(commit.references);
   }
 
   function formatPR(pr) {

--- a/lib/steps/pending-changes.js
+++ b/lib/steps/pending-changes.js
@@ -31,13 +31,64 @@
  */
 'use strict';
 
+var _ = require('lodash');
+
 var getCommits = require('../git/commits');
+var parseRepository = require('../github/parse-repository');
+
+var JIRA_PATTERN = /https?:\/\/[\w.-]+\/browse\/(\w+-)/;
+var GITHUB_PATTERN = /(https?:\/\/([\w.-]+))\/([^/]+)\/([^/]+)\/issues\//;
+
+function normalizeReferences(meta, commit) {
+  function normalizeInternalReference(ref) {
+    ref.owner = ref.owner || meta.username;
+    ref.repository = ref.repository || meta.repository;
+    ref.href = meta.htmlBase + '/' + ref.owner + '/' + ref.repository + '/issues/' + ref.issue;
+
+    if (ref.owner === meta.username && ref.repository === meta.repository) {
+      ref.prefix = '#';
+    } else {
+      ref.prefix = ref.owner + '/' + ref.repository + '#';
+    }
+  }
+
+  function normalizeReference(ref) {
+    // Cases:
+    // 1. It's a Jira-style url
+    // 2. It's a Github-style url
+    // 3. It's any other kind of url
+    // 4. We can trust owner/username/issue and resolve based on meta.htmlBase
+    var jiraMatch = ref.prefix.match(JIRA_PATTERN);
+    var ghMatch = ref.prefix.match(GITHUB_PATTERN);
+
+    if (jiraMatch) {
+      ref.prefix = jiraMatch[1];
+      ref.href = ref.raw;
+    } else if (ghMatch) {
+      ref.owner = ghMatch[3];
+      ref.repository = ghMatch[4];
+      if (ghMatch[1] !== meta.htmlBase) {
+        ref.href = ref.raw;
+        ref.prefix = ghMatch[2] + '/' + ref.owner + '/' + ref.repository + '#';
+      } else {
+        normalizeInternalReference(ref);
+      }
+    } else if (/^https?:\/\//.test(ref.prefix)) {
+      ref.prefix = '';
+      ref.href = ref.raw;
+    } else {
+      normalizeInternalReference(ref);
+    }
+  }
+  commit.references.forEach(normalizeReference);
+  return commit;
+}
 
 function getPendingChanges(cwd, pkg, options) {
+  var meta = parseRepository(pkg.repository);
   return getCommits(cwd, 'v' + pkg.version)
     .then(function setCommits(commits) {
-      options.commits = commits;
-      return commits;
+      options.commits = commits.map(_.partial(normalizeReferences, meta));
     });
 }
 module.exports = getPendingChanges;

--- a/test/fixtures/ticket-commits
+++ b/test/fixtures/ticket-commits
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -e
+git init
+git config user.name "nlm"
+git config user.email "nlm@example.com"
+
+echo "console.log('Short stuff');" > index.js
+git add index.js
+git commit -m 'fix: Short
+
+Closes #42'
+
+echo "console.log('Repo stuff');" > index.js
+git add index.js
+git commit -m 'fix: Repo
+
+Closes riley/thing#13'
+
+echo "console.log('Full stuff');" > index.js
+git add index.js
+git commit -m 'fix: Full
+
+Fixes https://github.com/open/source/issues/13'
+
+echo "console.log('Truncate stuff');" > index.js
+git add index.js
+git commit -m 'fix: Truncate
+
+Fixes https://github.com/usr/proj/issues/44'
+
+echo "console.log('GHE stuff');" > index.js
+git add index.js
+git commit -m 'fix: GHE
+
+Closes https://github.example.com/some/thing/issues/72'
+
+echo "console.log('Jira stuff');" > index.js
+git add index.js
+git commit -m 'fix: Jira
+
+Resolves https://jira.atlassian.com/browse/REPO-2001'

--- a/test/steps/changelog.test.js
+++ b/test/steps/changelog.test.js
@@ -46,6 +46,37 @@ describe('generateChangeLog', function () {
       });
   });
 
+  xit('links to github issues and jira tickets', function () {
+    var pkg = { repository: 'usr/proj' };
+    var commits = [
+      {
+        sha: '1234567890123456789012345678901234567890',
+        type: 'fix',
+        subject: 'Stop doing the wrong thing',
+        references: [
+          {},
+        ],
+      },
+      {
+        sha: '2234567890123456789012345678901234567890',
+        type: 'feat',
+        subject: 'Do more things',
+        references: [
+        ],
+      },
+    ];
+    var options = { commits: commits };
+    var href0 = 'https://github.com/usr/proj/commit/' + commits[0].sha;
+    var href1 = 'https://github.com/usr/proj/commit/' + commits[1].sha;
+    return generateChangeLog(null, pkg, options)
+      .then(function (changelog) {
+        assert.equal([
+          '* [`1234567`](' + href0 + ') **fix:** Stop doing the wrong thing',
+          '* [`2234567`](' + href1 + ') **feat:** Do more things',
+        ].join('\n'), changelog);
+      });
+  });
+
   it('can create a changelog for two commits', function () {
     var pkg = { repository: 'usr/proj' };
     var commits = [

--- a/test/steps/changelog.test.js
+++ b/test/steps/changelog.test.js
@@ -46,7 +46,7 @@ describe('generateChangeLog', function () {
       });
   });
 
-  xit('links to github issues and jira tickets', function () {
+  it('links to github issues and jira tickets', function () {
     var pkg = { repository: 'usr/proj' };
     var commits = [
       {
@@ -54,7 +54,12 @@ describe('generateChangeLog', function () {
         type: 'fix',
         subject: 'Stop doing the wrong thing',
         references: [
-          {},
+          {
+            action: 'Closes',
+            issue: '7',
+            prefix: 'fo/ba#',
+            href: 'https://gitub.com/fo/ba/issues/7',
+          },
         ],
       },
       {
@@ -62,6 +67,18 @@ describe('generateChangeLog', function () {
         type: 'feat',
         subject: 'Do more things',
         references: [
+          {
+            action: 'Resolves',
+            issue: '2010',
+            prefix: 'THING-',
+            href: 'https://example.com/browse/THING-7',
+          },
+          {
+            action: 'Fixes',
+            issue: '44',
+            prefix: '#',
+            href: 'https://github.com/usr/proj/issues/44',
+          },
         ],
       },
     ];
@@ -70,10 +87,16 @@ describe('generateChangeLog', function () {
     var href1 = 'https://github.com/usr/proj/commit/' + commits[1].sha;
     return generateChangeLog(null, pkg, options)
       .then(function (changelog) {
-        assert.equal([
-          '* [`1234567`](' + href0 + ') **fix:** Stop doing the wrong thing',
-          '* [`2234567`](' + href1 + ') **feat:** Do more things',
-        ].join('\n'), changelog);
+        var lines = changelog.split('\n');
+        assert.equal(
+          '* [`1234567`](' + href0 + ') **fix:** Stop doing the wrong thing - see: ' +
+            '[fo/ba#7](https://gitub.com/fo/ba/issues/7)',
+          lines[0]);
+        assert.equal(
+          '* [`2234567`](' + href1 + ') **feat:** Do more things - see: ' +
+            '[THING-2010](https://example.com/browse/THING-7), ' +
+            '[#44](https://github.com/usr/proj/issues/44)',
+          lines[1]);
       });
   });
 

--- a/test/steps/pending-changes.test.js
+++ b/test/steps/pending-changes.test.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2015, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+'use strict';
+
+var assert = require('assertive');
+var _ = require('lodash');
+
+var getPendingChanges = require('../../lib/steps/pending-changes');
+
+var withFixture = require('../fixture');
+
+describe('getPendingChanges', function () {
+  var dirname = withFixture('ticket-commits');
+  var pkg = {
+    version: '0.0.0',
+    repository: 'usr/proj',
+  };
+  var options = {};
+
+  before('create version commit', function () {
+    return getPendingChanges(dirname, pkg, options);
+  });
+
+  it('adds the commits to the options', function () {
+    assert.hasType(Array, options.commits);
+  });
+
+  it('resolves commit references', function () {
+    var commit = _.find(options.commits, { subject: 'Jira' });
+    assert.equal(1, commit.references.length);
+    var ref = commit.references[0];
+    assert.equal('REPO-', ref.prefix);
+    assert.equal('https://jira.atlassian.com/browse/REPO-2001', ref.href);
+  });
+
+  it('truncates full urls to same repo', function () {
+    var commit = _.find(options.commits, { subject: 'Truncate' });
+    assert.equal(1, commit.references.length);
+    var ref = commit.references[0];
+    assert.equal('#', ref.prefix);
+    assert.equal('https://github.com/usr/proj/issues/44', ref.href);
+  });
+
+  it('builds nice references to sibling repos', function () {
+    var commit = _.find(options.commits, { subject: 'Full' });
+    assert.equal(1, commit.references.length);
+    var ref = commit.references[0];
+    assert.equal('open/source#', ref.prefix);
+    assert.equal('https://github.com/open/source/issues/13', ref.href);
+  });
+
+  it('expands short-style refs', function () {
+    var commit = _.find(options.commits, { subject: 'Short' });
+    assert.equal(1, commit.references.length);
+    var ref = commit.references[0];
+    assert.equal('#', ref.prefix);
+    assert.equal('https://github.com/usr/proj/issues/42', ref.href);
+  });
+
+  it('supports refs to other Github instances', function () {
+    var commit = _.find(options.commits, { subject: 'GHE' });
+    assert.equal(1, commit.references.length);
+    var ref = commit.references[0];
+    assert.equal('github.example.com/some/thing#', ref.prefix);
+    assert.equal('https://github.example.com/some/thing/issues/72', ref.href);
+  });
+});


### PR DESCRIPTION
Most of the changes are additional tests. The short version is that `nlm` now accepts any url that ends with a number (more or less) as an acceptable argument to `Closes <x>`. There's special logic for both Jira-style and Github-style URLs to make them a bit prettier. This includes the "smart collapsing" Github itself does when a full URL is mentioned but it points to an issue in the current repository.