### PR TITLE
Never publish private packages

### DIFF
--- a/lib/steps/publish-to-npm.js
+++ b/lib/steps/publish-to-npm.js
@@ -136,6 +136,11 @@ function hasBasicAuth(env) {
 }
 
 function publishToNPM(cwd, pkg, options) {
+  if (pkg.private) {
+    debug('Skipping publish, package is set to private');
+    return Bluebird.resolve();
+  }
+
   _.defaults(options, {
     npmToken: process.env.NPM_TOKEN || '',
     npmPasswordBase64: process.env.NPM_PASSWORD_BASE64 || '',


### PR DESCRIPTION
If a package has `private: true` set, we can do Github releases etc. but we shouldn't try to publish it to npm.