### PR TITLE
Opt-in `acceptInvalidCommits` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ For more customization, you can use `.nlmrc` or an `nlm` section in `package.jso
 * `channels`: A map of branch name to npm `dist-tag`. When publishing, this will determine what will be published and how it's tagged. By default there's one entry in this map: `{ master: 'latest' }`. Which means that a publish from `master` updates the `latest` tag and publish from any other branch does nothing.
 * `license.files`: List of files and/or directories to add license headers to.
 * `license.exclude`: List of files to exclude that would otherwise be included. `nlm` will always exclude anything in `node_modules`.
+* `acceptInvalidCommits`: Accept commit messages even if they can't be parsed.
+  It's highly discouraged to use this option.
+  In this mode any commit with an invalid commit message will be treated as "semver-major".
 
 If there's no file named `LICENSE` in the repository, `nlm` won't attempt to add the headers.
 

--- a/lib/commands/verify.js
+++ b/lib/commands/verify.js
@@ -71,7 +71,8 @@ function verify(cwd, pkg, options) {
 
   function setReleaseType() {
     /* eslint no-console:0 */
-    options.releaseType = determineReleaseInfo(options.commits);
+    options.releaseType =
+      determineReleaseInfo(options.commits, options.acceptInvalidCommits);
     console.log('[nlm] Changes are %j', options.releaseType);
   }
 

--- a/lib/steps/release-info.js
+++ b/lib/steps/release-info.js
@@ -80,7 +80,7 @@ function isBreaking(note) {
 }
 
 var RELEASE_TYPES = ['none', 'patch', 'minor', 'major'];
-function determineReleaseInfo(commits) {
+function determineReleaseInfo(commits, acceptInvalidCommits) {
   var releaseType = 0;
 
   var invalidCommits = [];
@@ -117,7 +117,13 @@ function determineReleaseInfo(commits) {
   }
 
   if (invalidCommits.length) {
-    throw new InvalidCommitsError(invalidCommits);
+    if (acceptInvalidCommits) {
+      // Since we can't tell what those commits actually did,
+      // we always treat invalid commits as "major"
+      releaseType = 3;
+    } else {
+      throw new InvalidCommitsError(invalidCommits);
+    }
   }
 
   return RELEASE_TYPES[releaseType];

--- a/test/steps/release-info.test.js
+++ b/test/steps/release-info.test.js
@@ -82,5 +82,11 @@ describe('determineReleaseInfo', function () {
         '[2] https://git-scm.com/docs/git-rebase',
       ].join('\n'), error.message);
     });
+
+    describe('with --acceptInvalidCommits', function () {
+      it('is cautious and considers it "major"', function () {
+        assert.equal('major', determineReleaseInfo(commits, true));
+      });
+    });
   });
 });


### PR DESCRIPTION
Sometimes a project might pull in 3rd-party commits where rewording would not be acceptable, e.g. since it would complicate future merges. This isn't a great solution but it offers a stop-gap measure.