### PR TITLE
feat: re-check publish status for releaseType none

### DIFF
--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -76,10 +76,6 @@ function release(cwd, pkg, options) {
   }
 
   function runPublishTasks() {
-    if (options.releaseType === 'none') {
-      debug('Nothing to release');
-      return null;
-    }
     if (!!options.pr) {
       debug('Never publishing from a PR');
       return null;
@@ -91,6 +87,10 @@ function release(cwd, pkg, options) {
     if (!options.distTag) {
       debug('Skipping publish, no dist-tag');
       return null;
+    }
+    if (options.releaseType === 'none') {
+      debug('No changes; just verifying NPM publish');
+      publishTasks = [publishToNpm];
     }
     return Bluebird.each(publishTasks, runTask);
   }


### PR DESCRIPTION
If `npm publish` fails, you're left with a version that nlm believes is
real (has tag, CHANGELOG, GH Release, etc.), but that doesn't exist on
the npm registry.  Restarting the CI job doesn't help, because you
either get an attempted dup commit, or the changes are "none" so it
aborts.

This change makes it so that when you re-run a CI job for a version
bump/CHANGELOG commit, it will double-check that the current version
is published, and try (again) to publish it if it's not.