### PR TITLE
Only scan for files if LICENSE is present

### DIFF
--- a/lib/license/index.js
+++ b/lib/license/index.js
@@ -96,13 +96,7 @@ function addLicenseHeader(entry) {
   return entry;
 }
 
-function addMissingLicenseHeaders(files, licenseText) {
-  // No license available?
-  if (licenseText === null) {
-    debug('No LICENSE file found, skipping license headers');
-    return [];
-  }
-
+function addMissingLicenseHeaders(licenseText, files) {
   var licenseHeaders = {
     '.js': COMMENT_TYPES['.js'].getLicenseHeader(licenseText),
     '.coffee': COMMENT_TYPES['.coffee'].getLicenseHeader(licenseText),
@@ -127,15 +121,15 @@ function getLicenseText(cwd) {
     });
 }
 
-function collectMissingHeaders(cwd, whitelist, optionalExclude) {
-  return Bluebird.all([
-    // Collect all files that need a license header
-    collectFiles(cwd, whitelist, optionalExclude),
+function collectMissingHeaders(cwd, whitelist, optionalExclude, licenseText) {
+  // No license available?
+  if (licenseText === null) {
+    debug('No LICENSE file found, skipping license headers');
+    return [];
+  }
 
-    // Load the license text, minus surrounding whitespace
-    getLicenseText(cwd),
-
-  ]).spread(addMissingLicenseHeaders);
+  return collectFiles(cwd, whitelist, optionalExclude)
+    .then(_.partial(addMissingLicenseHeaders, licenseText));
 }
 
 function writeLicenseHeaders(entry) {
@@ -144,7 +138,8 @@ function writeLicenseHeaders(entry) {
 }
 
 function addLicenseHeaders(cwd, whitelist, optionalExclude) {
-  return collectMissingHeaders(cwd, whitelist, optionalExclude)
+  return getLicenseText(cwd)
+    .then(_.partial(collectMissingHeaders, cwd, whitelist, optionalExclude))
     .map(writeLicenseHeaders);
 }
 module.exports = addLicenseHeaders;


### PR DESCRIPTION
Previously a project that didn't have a LICENSE would have its entire workspace crawled before the result was dismissed.