### PR TITLE
acceptInvalidCommits formatter

### DIFF
--- a/lib/steps/changelog.js
+++ b/lib/steps/changelog.js
@@ -48,7 +48,7 @@ function addPullRequestCommits(pkg, commits, pr) {
       href: info.user.html_url,
     };
     pr.href = info.html_url;
-    pr.title = info.title;
+    pr.title = info.title || info.header;
     var shas = pr.shas = _.map(prCommits, 'sha');
     pr.commits = commits.filter(function isPartOfPR(commit) {
       return shas.indexOf(commit.sha) !== -1;
@@ -134,9 +134,13 @@ function generateChangeLog(cwd, pkg, options) {
   }
 
   function formatCommit(commit) {
-    return getCommitLink(commit) +
-      ' **' + commit.type + ':** ' +
-      commit.subject +
+    var subject;
+    if (commit.type) {
+      subject = '**' + commit.type + ':** ' + commit.subject;
+    } else {
+      subject = commit.header;
+    }
+    return getCommitLink(commit) + ' ' + subject +
       formatReferences(commit.references);
   }
 


### PR DESCRIPTION
It's easier to get teams to adopt `nlm` (and eventually good git practices) if it provides some value even before they change their ways. Fixes #16. (Seems I forgot to push this to github. :-)