### PR TITLE
Keep package-lock in sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nlm",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR only exists to work around a travis bug where rebuilding a branch that points to a tag causes a *tag* build instead of the actual branch build.