### PR TITLE
update version field in package-lock.json

### DIFF
--- a/lib/steps/version-commit.js
+++ b/lib/steps/version-commit.js
@@ -42,8 +42,8 @@ const run = require('../run');
 const NLM_GIT_NAME = 'nlm';
 const NLM_GIT_EMAIL = 'opensource@groupon.com';
 
-function addFiles(cwd) {
-  return run('git', ['add', 'CHANGELOG.md', 'package.json'], { cwd: cwd });
+function addFiles(cwd, files) {
+  return run('git', ['add'].concat(files), { cwd });
 }
 
 function commit(cwd, message) {
@@ -60,6 +60,25 @@ function commit(cwd, message) {
 
 function getHEAD(cwd) {
   return run('git', ['rev-parse', 'HEAD'], { cwd: cwd });
+}
+
+function updatePackageLockVersion(cwd, version, files) {
+  const lockPath = path.join(cwd, 'package-lock.json');
+  if (!fs.existsSync(lockPath)) return;
+
+  // if package-lock.json is in the .gitignore, then we just generated it
+  // and shouldn't commit it
+  const ignorePath = path.join(cwd, '.gitignore');
+  if (fs.existsSync(ignorePath)) {
+    const ignore = fs.readFileSync(ignorePath, 'utf8');
+    if (/^\/?package-lock\.json\s*$/m.test(ignore)) return;
+  }
+
+  // we don't want to risk re-sorting the file, so just do a regexp replace
+  const oldLock = fs.readFileSync(lockPath, 'utf8');
+  const newLock = oldLock.replace(/^( {2}"version": ")[^"]+/m, `$1${version}`);
+  fs.writeFileSync(lockPath, newLock);
+  files.push('package-lock.json');
 }
 
 function createVersionCommit(cwd, pkg, options) {
@@ -82,7 +101,10 @@ function createVersionCommit(cwd, pkg, options) {
   pkg.version = options.nextVersion;
   fs.writeFileSync(packageJsonFile, `${JSON.stringify(pkg, null, 2)}\n`);
 
-  return addFiles(cwd)
+  const files = ['CHANGELOG.md', 'package.json'];
+  updatePackageLockVersion(cwd, pkg.version, files);
+
+  return addFiles(cwd, files)
     .then(_.partial(commit, cwd, `v${pkg.version}`))
     .then(_.partial(getHEAD, cwd))
     .then(output => {

--- a/test/fixtures/with-bogus-plock
+++ b/test/fixtures/with-bogus-plock
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+bash $(dirname $0)"/multiple-commits"
+
+echo package-lock.json > .gitignore
+git add .gitignore
+git commit --amend --no-edit
+
+echo '{
+  "name": "nlm-test-pkg",
+  "version": "0.0.1",
+  "lockfileVersion": 1
+}' >package-lock.json

--- a/test/fixtures/with-plock
+++ b/test/fixtures/with-plock
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+bash $(dirname $0)"/multiple-commits"
+
+echo '{
+  "name": "nlm-test-pkg",
+  "version": "0.0.1",
+  "lockfileVersion": 1
+}' >package-lock.json
+git add package-lock.json
+git commit --amend --no-edit


### PR DESCRIPTION
iff you have an in-use `package-lock.json` (not in `.gitignore`),
as part of the version bump commit, we'll go ahead and bump the version
here too - that way you don't get a diff later on when you do an `npm i`