### PR TITLE
wrap risky co.wrap yields

### DIFF
--- a/lib/commands/changelog.js
+++ b/lib/commands/changelog.js
@@ -53,7 +53,7 @@ const showChangelog = co.wrap(function*(cwd, pkg, options) {
 
   const tasks = [ensureVersionTag, getPendingChanges, generateChangeLog];
 
-  for (const task of tasks) yield runTask(task);
+  for (const task of tasks) yield Promise.resolve(runTask(task));
 
   return printChangelog();
 });

--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -97,7 +97,7 @@ function release(cwd, pkg, options) {
       publishTasks = [publishToNpm];
     }
 
-    for (const task of publishTasks) yield runTask(task);
+    for (const task of publishTasks) yield Promise.resolve(runTask(task));
 
     return null;
   });

--- a/lib/commands/verify.js
+++ b/lib/commands/verify.js
@@ -102,11 +102,11 @@ function verify(cwd, pkg, options) {
   ];
 
   function runTask(task) {
-    return Promise.resolve(task(cwd, pkg, options));
+    return task(cwd, pkg, options);
   }
 
   const runVerifyTasks = co.wrap(function*() {
-    for (const task of verifyTasks) yield runTask(task);
+    for (const task of verifyTasks) yield Promise.resolve(runTask(task));
   });
 
   return runVerifyTasks();


### PR DESCRIPTION
Unlike real async/await, the yields you use with co.wrap explode if you
don't hand them a real Promise.  Let's just wrap the risky ones at their
point-of-use to make it easy to strip them back off when we port to real
async/await in the future.