### PR TITLE
feat: add support for hooks in release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ In most cases these settings are enough to make `nlm` do the right thing.
 For more customization, you can use `.nlmrc` or an `nlm` section in `package.json`:
 
 * `channels`: A map of branch name to npm `dist-tag`. When publishing, this will determine what will be published and how it's tagged. By default there's one entry in this map: `{ master: 'latest' }`. Which means that a publish from `master` updates the `latest` tag and publish from any other branch does nothing.
+* `hooks`: A map of hook names to shell commands. When executing any of the [commands](#commands) listed below some of these hooks will get triggered. The available hooks are:
+
+Hook      | Description 
+--------- | -----------
+`prepare` | Called when the release is about to be prepared. This is before updating files such as package.json, CHANGELOG.md and pushing a commit. It provides a reference to the **next version** number via the environment variable **NLM_NEXT_VERSION**.       
+
 * `license.files`: List of files and/or directories to add license headers to.
 * `license.exclude`: List of files to exclude that would otherwise be included. `nlm` will always exclude anything in `node_modules`.
 * `acceptInvalidCommits`: Accept commit messages even if they can't be parsed.
@@ -121,6 +127,7 @@ Verify that the current state is valid and could be released.
 Will also add license headers where they are missing.
 
 1. Everything `nlm verify` does.
+1. If `hooks#prepare` is present in the `nlm` section of the `package.json`, the shell command defined by the hook will be executed.
 1. If there are unreleased changes:
   1. Create a new CHANGELOG entry and update `package.json#version`.
   1. Commit and tag the release.

--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -41,6 +41,7 @@ const createVersionCommit = require('../steps/version-commit');
 const pushReleaseToRemote = require('../steps/push-to-remote');
 const createGithubRelease = require('../steps/github-release');
 const publishToNpm = require('../steps/publish-to-npm');
+const executePrepareHookCommand = require('../steps/execute-prepare-hook-command');
 
 const runVerify = require('./verify');
 
@@ -68,6 +69,7 @@ function release(cwd, pkg, options) {
 
   let publishTasks = [
     setNextVersion,
+    executePrepareHookCommand,
     generateChangeLog,
     createVersionCommit,
     pushReleaseToRemote,

--- a/lib/steps/execute-prepare-hook-command.js
+++ b/lib/steps/execute-prepare-hook-command.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict' /* eslint no-console:0 */;
+
+const childprocess = require('child_process');
+
+function executePrepareHookCommand(cwd, pkg, options) {
+  const prepareHook = options.hooks && options.hooks.prepare;
+  if (!prepareHook) return;
+  console.log(`
+  [nlm] Executing 'prepare' hook command: ${options.hooks.prepare}`);
+  const env = Object.assign({}, process.env, {
+    NLM_NEXT_VERSION: options.nextVersion,
+  });
+  childprocess.execSync(`${options.hooks['prepare']}`, {
+    cwd,
+    stdio: 'inherit',
+    env,
+  });
+}
+module.exports = executePrepareHookCommand;

--- a/lib/steps/execute-prepare-hook-command.js
+++ b/lib/steps/execute-prepare-hook-command.js
@@ -38,11 +38,11 @@ function executePrepareHookCommand(cwd, pkg, options) {
   const prepareHook = options.hooks && options.hooks.prepare;
   if (!prepareHook) return;
   console.log(`
-  [nlm] Executing 'prepare' hook command: ${options.hooks.prepare}`);
+  [nlm] Executing 'prepare' hook command: ${prepareHook}`);
   const env = Object.assign({}, process.env, {
     NLM_NEXT_VERSION: options.nextVersion,
   });
-  childprocess.execSync(`${options.hooks['prepare']}`, {
+  childprocess.execSync(prepareHook, {
     cwd,
     stdio: 'inherit',
     env,

--- a/test/steps/execute-prepare-hook-command.test.js
+++ b/test/steps/execute-prepare-hook-command.test.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2015, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* eslint-disable import/no-dynamic-require */
+
+'use strict';
+
+const fs = require('fs');
+
+const assert = require('assertive');
+
+const executePrepareHookCommand = require('../../lib/steps/execute-prepare-hook-command');
+
+const withFixture = require('../fixture');
+
+describe('executePrepareHookCommand', () => {
+  const dirname = withFixture('empty-project');
+
+  describe('when no hooks', () => {
+    it('does nothing', () => {
+      executePrepareHookCommand(dirname, null, {});
+    });
+  });
+
+  describe('when hooks is empty', () => {
+    it('does nothing', () => {
+      executePrepareHookCommand(dirname, null, {
+        hooks: {},
+      });
+    });
+  });
+
+  describe('when hooks does not contain *prepare* hook', () => {
+    it('does nothing', () => {
+      executePrepareHookCommand(dirname, null, {
+        hooks: { dummy: 'blabla' },
+      });
+    });
+  });
+
+  describe('when hooks contains *prepare* hook', () => {
+    it('executes the command defined in the value', () => {
+      const expectedVersion = '1.0.0';
+      const tmpFilename = 'tmp.txt';
+      executePrepareHookCommand(dirname, null, {
+        nextVersion: expectedVersion,
+        hooks: { prepare: `printf $NLM_NEXT_VERSION >> ${tmpFilename}` },
+      });
+      const version = fs.readFileSync(`${dirname}/${tmpFilename}`, 'utf8');
+      assert.equal(version, expectedVersion);
+    });
+  });
+});

--- a/test/steps/execute-prepare-hook-command.test.js
+++ b/test/steps/execute-prepare-hook-command.test.js
@@ -76,7 +76,7 @@ describe('executePrepareHookCommand', () => {
         hooks: { prepare: `printf $NLM_NEXT_VERSION >> ${tmpFilename}` },
       });
       const version = fs.readFileSync(`${dirname}/${tmpFilename}`, 'utf8');
-      assert.equal(version, expectedVersion);
+      assert.equal(expectedVersion, version);
     });
   });
 });


### PR DESCRIPTION
This PR adds support for hooks in `nlm release` command. So far only one hook has been implemented but the design allows to add more hooks in the future without breaking changes. 

The hook implemented is the `prepare` hook, which is called between version bump and commit steps and is capable of executing any given shell command. This command should be defined in the an `nlm` section in `package.json`, like this: 
```javascript
"nlm": {
  "hooks": {
    "prepare": "<add_your_command_here>"
  }
}
```
As part of the command execution `nlm` will provide the value of the **nextVersion** as an environment variable **NLM_NEXT_VERSION**.