### PR TITLE
feat: support circleci PRs and releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ build:
 
 #### CircleCI
 
-You may reference teh official [circleci docs](https://circleci.com/docs/2.0/env-vars/) on setting up environment variables
+You may reference the official [circleci docs](https://circleci.com/docs/2.0/env-vars/) on setting up environment variables
 using the admin console.
 
 `nlm` will look for `CIRCLE_BRANCH` and `CIRCLE_PULL_REQUEST` environment variables to operate correctly.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ and tagging issues. Github has instructions for
 
 `nlm` will automatically look for well-known environment variables during CI
 builds like `CI=true`, `BRANCH=branch-name`, etc.
-It should work out-of-the-box for both [Travis](https://travis-ci.org/) and
-[DotCI](https://groupon.github.io/DotCi/).
+It should work out-of-the-box for [Travis](https://travis-ci.org/),
+[DotCI](https://groupon.github.io/DotCi/), and [CircleCI](https://circleci.com/).
 
 For Github and npm interactions to work, it requires the following additional environment variables:
 
@@ -81,6 +81,25 @@ build:
   after:
     - ./node_modules/.bin/nlm publish
   <% } %>
+```
+
+#### CircleCI
+
+You may reference teh official [circleci docs](https://circleci.com/docs/2.0/env-vars/) on setting up environment variables
+using the admin console.
+
+`nlm` will look for `CIRCLE_BRANCH` and `CIRCLE_PULL_REQUEST` environment variables to operate correctly.
+
+To enable publishing, you may add a check in your run steps for a branch and build you want to release on:
+
+```yaml
+- run: |
+    if [ "$CIRCLE_BRANCH" == "master" ] && [ "$CIRCLE_STAGE" == "test-3" ]; then
+          echo "Running nlm release";
+          npx nlm release;
+    else
+          echo "Not running nlm release!";
+    fi
 ```
 
 ## Configuration

--- a/lib/commands/verify.js
+++ b/lib/commands/verify.js
@@ -71,6 +71,12 @@ function getPullRequestId() {
     return dotciId;
   }
 
+  const circleCiPullUrl = process.env.CIRCLE_PULL_REQUEST;
+  if (circleCiPullUrl && circleCiPullUrl !== 'false') {
+    const circleCiId = circleCiPullUrl.split('/').pop();
+    return circleCiId;
+  }
+
   return '';
 }
 

--- a/lib/steps/detect-branch.js
+++ b/lib/steps/detect-branch.js
@@ -39,7 +39,9 @@ function getEnvBranch() {
     return process.env.TRAVIS_BRANCH;
   }
 
-  return process.env.DOTCI_BRANCH || process.env.BRANCH;
+  return (
+    process.env.DOTCI_BRANCH || process.env.CIRCLE_BRANCH || process.env.BRANCH
+  );
 }
 
 function detectBranch(cwd, pkg, options) {


### PR DESCRIPTION
Adding support for CircleCI.

* circleci uses the `CIRCLE_PULL_REQUEST` env var to designate the pull request URL (I pull the id from it in the code)
* circleci uses the `CIRCLE_BRANCH` env var to designate the branch
* added some description in the `READEME` on how to setup auto releasing from master builds

Testing `nlm` with circleci here in this PR: https://github.com/Automattic/vip-search-replace/pull/1
And am currently not getting auto labelling of semver updates on the PR without these changes.

Please feel free to add a `hacktoberfest-accepted` label to the PR if you feel it's worthy 👍  🤓 🙇‍♂️ 