### PR TITLE
fix(changelog): type(scope) detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The default emojis for the commit types are:
   "style": "💅",
   
   // internal types
-  "deps": "🔼",     // will be set when dependencies are found in PR commit subject
+  "dep": "🔼",     // will be set when dependencies are found in PR commit subject
   "internal": "🏡", // will be set for types: "chore", "build", "test", "ci" or commits without type
 
 }

--- a/lib/steps/changelog.js
+++ b/lib/steps/changelog.js
@@ -128,7 +128,7 @@ function getTypeCategory(type, options) {
       descr = 'Bug Fixes';
       break;
 
-    case 'dep':
+    case 'deps':
       descr = 'Dependencies';
       break;
 
@@ -172,7 +172,7 @@ function sortByType(data) {
     'perf',
     'refactor',
     'fix',
-    'dep',
+    'deps',
     'revert',
     'style',
     'docs',
@@ -195,10 +195,10 @@ function sortByType(data) {
  * @return {string}
  */
 function getType(title) {
-  const match = title.match(/^(\w+):/);
+  const match = title.match(/^(\w+)[:(]/);
   let type = match && match[1];
-  if (findDependency(title)) {
-    type = 'dep';
+  if (findDependency(title) && type === 'chore') {
+    type = 'deps';
   }
   return type || 'internal';
 }


### PR DESCRIPTION
- [x] fix(changelog): type(scope) detection

Will now be able to categorise PRs containing scopes like `fix(changelog): something`