### PR TITLE
ci(actions): fix publish to default branch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,7 +6,7 @@ name: Publish to NPM
 
 on:
   push:
-    branches: [ main ]
+    branches: [ $default-branch ]
 
 jobs:
   build:
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: 14
       - run: npm ci
-      - run: DEBUG=nlm* npx nlm release
+      - run: npx nlm release
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,3 +1,4 @@
+
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
@@ -29,7 +30,7 @@ jobs:
         with:
           node-version: 14
       - run: npm ci
-      - run: npx nlm release
+      - run: DEBUG=nlm* npx nlm release
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ To have `nlm` release on merge to the default branch or other branches, you need
 - set the trigger to the `push` event
   ```yaml
   push:
-    branches: [ main, v10.x ] # branches to release from
+    branches: [ $default-branch, v10.x ] # default branch placeholder + branches to release from
   ```
 - pass the `GH_TOKEN` and `NPM_TOKEN` to the env
   ```yaml
@@ -239,7 +239,7 @@ name: Publish to NPM
 
 on:
   push:
-    branches: [ main ] # default branch
+    branches: [ $default-branch ] # use default branch placeholder
 
 jobs:
   build:


### PR DESCRIPTION
🤦  copy & paste

- [x] ci(actions): set `$default-branch` placeholder for publish workflow
- [x] docs: updated example with placeholder 

https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization