### PR TITLE
Undo commit listing changes from #90

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: 14
       - run: npm ci
-      - run: npx nlm release
+      - run: ./bin/nlm.js release --commit
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/lib/git/commits.js
+++ b/lib/git/commits.js
@@ -33,35 +33,21 @@
 'use strict';
 
 const commitParser = require('conventional-commits-parser');
-const semver = require('semver');
 
 const debug = require('debug')('nlm:git:commits');
 
 const run = require('../run');
 
 const SEPARATOR = '---nlm-split---';
+const GIT_LOG_FORMAT = `--format=%H %P\n%B${SEPARATOR}`;
 const PR_MERGE_PATTERN = /^Merge pull request #(\d+) from ([^\/]+)\/([\S]+)/;
 
-const EMPTY_STATE_MESSAGE =
-  /bad default revision 'HEAD'|does not have any commits yet/;
-
-function gracefulEmptyState(error) {
-  if (EMPTY_STATE_MESSAGE.test(error.message)) {
-    debug('Assuming this was executed before the first commit was made');
-    return '';
-  }
-
-  throw error;
-}
-
-/**
- * @param {string} commitSection
- * @returns {{parentSha: string|null, sha: string|null, type: string|null, revert?: {message: string}, header: string|null, pullId: number|null}}
- */
-function parseCommit(commitSection) {
-  const [sha, parentSha, , ...body] = commitSection.split('\n');
-  const message = body.join('\n');
-
+function parseCommit(commit) {
+  const metaEndIdx = commit.indexOf('\n');
+  const meta = commit.slice(0, metaEndIdx).trim().split(' ');
+  const message = commit.slice(metaEndIdx + 1);
+  const sha = meta.shift();
+  const parentSha = meta.shift() || null;
   const data = commitParser.sync(message, {
     issuePrefixes: ['#', 'https?://[\\w\\.-/]*[-/]+'],
     revertPattern: /^revert:?\s"([\s\S]*)"/i,
@@ -97,108 +83,53 @@ function parseCommit(commitSection) {
     }
   }
 
-  return { ...data, sha: sha || data.sha, parentSha: parentSha || null };
+  return { ...data, sha: sha || data.sha, parentSha };
 }
 
-/**
- * @param {{type?: string, header?:string}} commit
- * @returns {boolean}
- */
 function isNotRandomMerge(commit) {
   // DotCI adds these :(
   return commit.type || `${commit.header}`.indexOf('Merge ') !== 0;
 }
 
-/**
- * Get only relevant commits
- * If a tag exist, only commits newer than the tag are returned,
- * otherwise all
- *
- * @param {string[]} sections
- * @returns {string[]}
- */
-function findRelevant(sections) {
-  const index = sections.findIndex(section => {
-    // check for version tags i.e v10.3.0 that are at the beginning of the raw body
-    const match = section.match(/\n(v\d+\.\d+\.\d+)/);
-    return match && semver.valid(match[1]);
-  });
-  if (index > -1) {
-    sections = sections.slice(0, index);
-  }
-
-  return sections.filter(section => section.trim());
-}
-
-/**
- * @param {string} stdout
- * @returns {string[]}
- */
 function parseLogOutput(stdout) {
-  const sections = findRelevant(stdout.split(SEPARATOR));
-
-  return sections.reduceRight((acc, commitSection) => {
-    const commit = parseCommit(commitSection.trim());
-    if (isNotRandomMerge(commit)) {
-      acc.push(commit);
-    }
-    return acc;
-  }, []);
+  return stdout
+    .split(SEPARATOR)
+    .map(s => s.trim())
+    .filter(s => !!s)
+    .map(parseCommit)
+    .filter(isNotRandomMerge);
 }
 
-/**
- * @param {string} cwd
- * @returns {Promise<string>}
- */
-async function getRemoteBranch(cwd) {
-  try {
-    const remoteData = await run('git', ['remote', 'show', 'origin'], {
-      cwd,
-      showStdout: false,
-    });
-    const match = remoteData.match(/HEAD branch: (\w+)/);
-    if (match) {
-      return `origin/${match[1]}`;
-    }
-  } catch (e) {
-    /* This might fail in CI / tests - we can use `git status -sb` instead*/
+const EMPTY_STATE_MESSAGE =
+  /bad default revision 'HEAD'|does not have any commits yet/;
+
+function gracefulEmptyState(error) {
+  if (EMPTY_STATE_MESSAGE.test(error.message)) {
+    debug('Assuming this was executed before the first commit was made');
+    return [];
   }
 
-  // Show the branch and tracking info even in short-format
-  const stdout = await run('git', ['status', '-sb'], { cwd }).catch(() => '');
-
-  // i.e. ## tagging...origin/main
-  const match = stdout.match(/#{2} [\w-]+\.{3}(\w+\/[\w-.\/]+)/);
-  return match ? match[1] : '';
+  throw error;
 }
 
-/**
- * @param {string} cwd
- * @returns {Promise<string[]>}
- */
-async function getCommits(cwd) {
-  const remote = await getRemoteBranch(cwd);
-  const range = remote ? `${remote}...HEAD` : [];
+function createRange(fromRevision) {
+  if (fromRevision && fromRevision !== 'v0.0.0') {
+    return `${fromRevision}..HEAD`;
+  }
 
-  debug('range', range);
+  return [];
+}
 
-  // https://devhints.io/git-log-format
-  // %H - commit hash
-  // %P - parent hash
-  // %D - refs
-  // %B - raw body
-  const logArgs = [
-    'log',
-    '--topo-order',
-    `--format=%H\n%P\n%D\n%B${SEPARATOR}`,
-  ];
-
-  // get local commits
-  const stdout = await run('git', logArgs.concat(range), { cwd }).catch(err =>
-    gracefulEmptyState(err)
-  );
-
-  return parseLogOutput(stdout);
+function getCommits(directory, fromRevision) {
+  return run(
+    'git',
+    ['log', '--reverse', '--topo-order', GIT_LOG_FORMAT].concat(
+      createRange(fromRevision)
+    ),
+    {
+      cwd: directory,
+    }
+  ).then(parseLogOutput, gracefulEmptyState);
 }
 
 module.exports = getCommits;

--- a/lib/steps/pending-changes.js
+++ b/lib/steps/pending-changes.js
@@ -87,7 +87,7 @@ function normalizeReferences(meta, commit) {
 }
 
 async function getPendingChanges(cwd, pkg, options) {
-  const commits = await getCommits(cwd);
+  const commits = await getCommits(cwd, `v${pkg.version}`);
 
   const meta = parseRepository(pkg.repository);
   options.commits = commits.map(commit => normalizeReferences(meta, commit));

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "pretest": "eslint lib test",
     "test": "c8 mocha",
-    "posttest": "DEBUG=nlm* ./bin/nlm.js verify"
+    "posttest": "./bin/nlm.js verify"
   },
   "engines": {
     "node": ">=10.13"

--- a/test/fixtures/multiple-commits
+++ b/test/fixtures/multiple-commits
@@ -6,12 +6,6 @@ bash $(dirname $0)/fix-commit
 
 git checkout -b noise
 
-echo "console.log('');" > second.js
-git add second.js
-git commit -m "v0.0.5"
-git tag 'v0.0.5'
-
-
 echo "console.log('more');" > second.js
 git add second.js
 git commit -m "fix: Adding second
@@ -30,7 +24,6 @@ git checkout -b my-feature
 echo "console.log('other stuff');" > index.js
 git add index.js
 git commit -m 'feat: Changed more stuff'
-
 
 git checkout master
 git merge my-feature --no-ff -m 'Merge pull request #119 from theowner/some/branch'

--- a/test/git/commits.test.js
+++ b/test/git/commits.test.js
@@ -83,7 +83,7 @@ describe('getCommits', () => {
       }
     }
 
-    before('fetch al commits', () => {
+    before('fetch all commits', () => {
       return getCommits(dirname).then(commits => {
         allCommits = commits;
       });
@@ -154,7 +154,7 @@ describe('getCommits', () => {
   describe('with multiple commits', () => {
     const dirname = withFixture('multiple-commits');
     let allCommits = null;
-    before('fetch al commits', () => {
+    before('fetch all commits', () => {
       return getCommits(dirname).then(commits => {
         allCommits = commits;
       });


### PR DESCRIPTION
The intention of #90 was to limit the scope of change calculations to
only those on the local branch.  This is problematic for a number of
reasons:

1. It actually makes publishing in the standard CI flow impossible - the
   nlm job runs after the PR has already been merged to main, making the
   list of commits zero.  The only reason this release published
   successfully is that this repo was set to use the prior version of
   `nlm`, thus evading this bug (fixed in additional commit on this PR)
2. It results in inaccurate version bump selection/CHANGELOG entries:
   the release will include **everything** on `main`, not just the
   commits in the current branch, so we shouldn't publish a false
   record of activity.

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.4)_